### PR TITLE
Upgrade to cortex-m-rt 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,5 @@
 First release. `imxrt-rt` provides a build-time API that defines a memory map,
 as well as a runtime library that configures i.MX RT 10xx and 11xx processors.
 
-[Unreleased]: https://github.com/imxrt-rs/imxrt-rt/compare/0.1.0...HEAD
-[0.1.0]: https://github.com/imxrt-rs/imxrt-rt/releases/tag/0.1.0
+[Unreleased]: https://github.com/imxrt-rs/imxrt-rt/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/imxrt-rs/imxrt-rt/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,21 @@
 
 ## [Unreleased]
 
+## [0.1.1] 2023-02-14
+
+Update to cortex-m-rt 0.7.3 to avoid certain miscompilation opportunities.
+For more information, see the [cortex-m-rt advisory][cmrt-0.7.3].
+
+[cmrt-0.7.3]: https://github.com/rust-embedded/cortex-m/discussions/469
+
+Note that imxrt-rt 0.1.0 will no longer build. If you observe this error,
+ensure that your build uses this imxrt-rt release.
+
 ## [0.1.0] 2022-12-02
 
 First release. `imxrt-rt` provides a build-time API that defines a memory map,
 as well as a runtime library that configures i.MX RT 10xx and 11xx processors.
 
-[Unreleased]: https://github.com/imxrt-rs/imxrt-rt/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/imxrt-rs/imxrt-rt/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/imxrt-rs/imxrt-rt/releases/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/imxrt-rs/imxrt-rt/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ device = ["cortex-m-rt/device"]
 cfg-if = "1.0"
 
 [target.'cfg(all(target_arch = "arm", target_os = "none"))'.dependencies]
-cortex-m-rt = { version = "=0.7.2", features = ["set-vtor", "set-sp"] }
+cortex-m-rt = { version = "=0.7.3", features = ["set-vtor", "set-sp"] }
 
 [target.'cfg(all(target_arch = "arm", target_os = "none"))'.dev-dependencies]
 board = { path = "board" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imxrt-rt"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/imxrt-rs/imxrt-rt"


### PR DESCRIPTION
Closes #7. I tested this by building and running the two examples in this repo on a 1010EVK. Also tested in imxrt-hal by building and running examples on a 1010EVK.

This will become the 0.1.1 imxrt-rt release.