### PR TITLE
Generate one linker script; add unit tests

### DIFF
--- a/src/host/imxrt-boot-header.x
+++ b/src/host/imxrt-boot-header.x
@@ -1,4 +1,5 @@
-/* This extra file is injected into imxrt-memory.x depending on the
+/* ===--- Begin imxrt-boot-header.x ---===
+ * This extra content is injected into the linker script depending on the
  * runtime configuration.
  */
 
@@ -71,3 +72,5 @@ SECTIONS
     . = ORIGIN(FLASH) + 0x2000;   /* Reserve the remaining 8K as a convenience for a non-XIP boot. */
   } > FLASH
 }
+
+/* ===--- End imxrt-boot-header.x ---=== */

--- a/src/host/imxrt-link.x
+++ b/src/host/imxrt-link.x
@@ -1,11 +1,7 @@
-/*
- * This linker script is a fork of the default linker script provided by
+/* ===--- Begin imxrt-link.x ---===
+ * This section of the linker script is a fork of the default linker script provided by
  * imxrt-rt, version 0.7.1. It's modified to support the needs of imxrt-rt.
  */
-
-/* Provides information about the memory layout of the device */
-/* This will be provided by the build script that uses imxrt-rt. */
-INCLUDE imxrt-memory.x
 
 /* # Entry point = reset vector */
 EXTERN(__RESET_VECTOR);
@@ -196,3 +192,5 @@ Dynamic relocations are not supported. If you are linking to C code compiled usi
 the 'cc' crate then modify your build script to compile the C code _without_
 the -fPIC flag. See the documentation of the `cc::Build.pic` method for details.");
 /* Do not exceed this mark in the error messages above                                    | */
+
+/* ===--- End imxrt-link.x ---=== */


### PR DESCRIPTION
We can still maintain individual linker script components, then write them into one, larger linker script. That's what INCLUDE does anyway.

Once we have one linker script, we can refactor for easier unit testing. This commit adds simple unit tests for the default builder, and some of the expected errors.