### PR TITLE
Add optional DCD section in the firmware image linker script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+Add section for device configuration data (DCD) in linker script. Users
+can place their DCD in a section called `.dcd`. Consider using imxrt-dcd
+as a convenient way to define a DCD.
+
 ## [0.1.1] 2023-02-14
 
 Update to cortex-m-rt 0.7.3 to avoid certain miscompilation opportunities.

--- a/board/Cargo.toml
+++ b/board/Cargo.toml
@@ -45,3 +45,8 @@ imxrt1170evk-cm7 = [
     "dep:rtt-target",
     "dep:panic-rtt-target",
 ]
+
+# Dummy boards for testing DCD linking.
+# Don't try running these on hardware; they might not work.
+__dcd = ["teensy4"]
+__dcd_missize = ["teensy4"]

--- a/board/src/teensy4.rs
+++ b/board/src/teensy4.rs
@@ -35,3 +35,18 @@ pub fn prepare(timer_delay_microseconds: u32) -> Option<crate::Resources> {
         pit,
     })
 }
+
+/// Dummy DCD section containing a single NOP command (for testing linker scripts).
+#[cfg(feature = "__dcd")]
+#[link_section = ".dcd"]
+#[no_mangle]
+#[used]
+pub static DEVICE_CONFIGURATION_DATA: [u8; 8] = [0xD2, 0x00, 0x08, 0x41, 0xC0, 0x00, 0x04, 0x00];
+
+/// Ditto but incorrect size (not a multiple of 4 bytes). The linker script should catch this error
+/// and fail the build.
+#[cfg(feature = "__dcd_missize")]
+#[link_section = ".dcd"]
+#[no_mangle]
+#[used]
+pub static DEVICE_CONFIGURATION_DATA: [u8; 7] = [0xD2, 0x00, 0x08, 0x41, 0xC0, 0x00, 0x04];

--- a/src/host/imxrt-boot-header.x
+++ b/src/host/imxrt-boot-header.x
@@ -53,7 +53,7 @@ SECTIONS
     LONG(0x402000D1);           /* Header, magic number */
     LONG(__sivector_table);     /* Address of the vectors table */
     LONG(0x00000000);           /* RESERVED */
-    LONG(0x00000000);           /* Device Configuration Data (unused) */
+    LONG(__dcd);                /* Device Configuration Data */
     LONG(__boot_data);          /* Address to boot data */
     LONG(__ivt);                /* Self reference */
     LONG(0x00000000);           /* Command Sequence File (unused) */
@@ -67,6 +67,11 @@ SECTIONS
     LONG(__image_size);         /* Length of image */
     LONG(0x00000000);           /* Plugin flag (unused) */
     LONG(0xDEADBEEF);           /* Dummy to align boot data to 16 bytes */
+    . = ALIGN(4);
+    __dcd_start = .;
+    KEEP(*(.dcd));              /* Device Configuration Data */
+    __dcd_end = .;
+    __dcd = ((__dcd_end - __dcd_start) > 0) ? __dcd_start : 0;
     *(.Reset);                  /* Jam the imxrt-rt reset handler into flash. */
     *(.__pre_init);             /* Also jam the pre-init function, since we need it to run before instructions are placed. */
     . = ORIGIN(FLASH) + 0x2000;   /* Reserve the remaining 8K as a convenience for a non-XIP boot. */

--- a/src/host/imxrt-link.x
+++ b/src/host/imxrt-link.x
@@ -191,6 +191,9 @@ ERROR(imxrt-rt): .got section detected in the input object files
 Dynamic relocations are not supported. If you are linking to C code compiled using
 the 'cc' crate then modify your build script to compile the C code _without_
 the -fPIC flag. See the documentation of the `cc::Build.pic` method for details.");
+
+ASSERT((__dcd_end - __dcd_start) % 4 == 0, "
+ERROR(imxrt-rt): .dcd (Device Configuration Data) size must be a multiple of 4 bytes.");
 /* Do not exceed this mark in the error messages above                                    | */
 
 /* ===--- End imxrt-link.x ---=== */


### PR DESCRIPTION
> Foreword: I am not familiar with the best practices / coding styles of linker scripts. For now, this is a proof-of-concept. Feedback and refactors are welcome!

# Background

I am working on adding DCD (Device Configuration Data) support to the `imxrt-rs` ecosystem.
See RT1060 RM rev.3 §9.7.2 for the official specification of DCD.

My plan is:
- [x] Write a DCD binary generator callable from build script.
  - This is <https://crates.io/crates/imxrt-dcd>
- [x] Embed this DCD binary into a static variable somewhere in the firmware crate's build tree, with `#[no_mangle]` and linker section specified.
  - <https://crates.io/crates/static-include-bytes>  makes this easier.
- [ ] Make the main loader script include the DCD section
  - The purpose of this PR 😉 

# Solution

To avoid having the DCD pointer in IVT point at bogus data, I only set it to `__dcd_start` if there is _something_ in the `.dcd` section.

# Test

https://gist.github.com/summivox/06ed07f1ac13dcfc53595c2bd73ce69c

It works on my Teensy 4.1. Since I am just starting to build my firmware infra, I resorted to the most bare-metal debugging method: flashing the LED to exfiltrate the register that the DCD is supposed to have set, bit-by-bit.