### PR TITLE
Add environment variable overrides for stack, heap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+Add configurations to `RuntimeBuilder`:
+
+- `stack_size_env_override`
+- `heap_size_env_override`
+
+Use these methods to define environment variables that can override the
+stack / heap sizes.
+
 ## [0.1.3] 2023-10-01
 
 Ensure that the runtime supports the GNU linker, `ld`.

--- a/board/build.rs
+++ b/board/build.rs
@@ -28,6 +28,9 @@ fn main() {
                     .data(imxrt_rt::Memory::Dtcm)
                     .bss(imxrt_rt::Memory::Dtcm)
                     .uninit(imxrt_rt::Memory::Dtcm)
+                    .stack_size_env_override("THIS_WONT_BE_CONSIDERED")
+                    .stack_size_env_override("BOARD_STACK")
+                    .heap_size_env_override("BOARD_HEAP")
                     .build()
                     .unwrap()
             }
@@ -37,6 +40,8 @@ fn main() {
             )
             .heap_size(1024)
             .rodata(imxrt_rt::Memory::Flash)
+            .stack_size_env_override("BOARD_STACK")
+            .heap_size_env_override("BOARD_HEAP")
             .build()
             .unwrap(),
             "imxrt1170evk_cm7" => imxrt_rt::RuntimeBuilder::from_flexspi(
@@ -44,6 +49,8 @@ fn main() {
                 16 * 1024 * 1024,
             )
             .rodata(imxrt_rt::Memory::Dtcm)
+            .stack_size_env_override("BOARD_STACK")
+            .heap_size_env_override("BOARD_HEAP")
             .build()
             .unwrap(),
             _ => continue,


### PR DESCRIPTION
If you define a runtime, you can call `stack_size_env_override` to define an optional environment variable checked by the runtime builder. Same goes for the heap. A user can set these environment variables to override the runtime's stack / heap size.

There's no default environment variable for either memory region. The package that defines the runtime needs to opt-in to this feature.