### PR TITLE
Support RT1180 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+Add initial support for RT1180.
+
 ## [0.1.4] 2024-04-05
 
 Add configurations to `RuntimeBuilder`:

--- a/src/host/imxrt-boot-header-1180.x
+++ b/src/host/imxrt-boot-header-1180.x
@@ -1,0 +1,104 @@
+/* ===--- Begin imxrt-boot-header-1180.x ---===
+ * This extra content is injected into the linker script depending on the
+ * runtime configuration.
+ */
+
+__image_size = SIZEOF(.vector_table) + SIZEOF(.text) + SIZEOF(.xip) + SIZEOF(.rodata) + SIZEOF(.data);
+
+EXTERN(FLEXSPI_CONFIGURATION_BLOCK);
+
+/* # Sections */
+SECTIONS
+{
+  /* Boot header for serial NOR FlexSPI XIP.
+   *
+   * It's 'XIP' in that it starts executing instructions
+   * from flash immediately out of reset. The runtime then
+   * manually copies instructions (data, etc.), and we jump
+   * to that. After that jump, we're no longer XIP.
+   *
+   * The i.MX RT boot ROM also supports a way to copy the
+   * application image by changing the boot data configuration.
+   * Specifically, point the 'Image offset' to somewhere other
+   * than the start of flash, and specify how many bytes to copy.
+   * The boot ROM copies the image, then jumps to the entry point.
+   * It is currently not tested or used, mainly  for consistency
+   * with the other iMXRT families.
+   */
+  .boot1 ORIGIN(FLASH):
+  {
+    FILL(0x00);
+    /* ------------------
+     * Memory configuration block
+     * ------------------
+     *
+     * The size and layout is different for different boot devices. Currently,
+     * only NOR flash is supported.
+     */
+    . += __fcb_offset;          /* Can change based on boot source */
+    KEEP(*(.fcb));
+    . = ORIGIN(FLASH) + 0x1000;
+
+    /* ------------------
+     * Container 1
+     * ------------------
+     */
+    __container1_start = .;
+    LONG(0x87000000 | (__container1_len << 8)); /* Tag, length, version */
+    LONG(0); /* Flags */
+    LONG(0x01000000); /* 1 image, fuse version 0, SW version 0 */
+    LONG(__signature_block_start - __container1_start); /* Signature block offset */
+
+    /* Image array, image 0 */
+    LONG(0xa000); /* Image offset */
+    LONG(__image_size); /* Image size */
+    QUAD(LOADADDR(.vector_table)); /* Load address (execute in place) */
+    QUAD(Reset); /* Entry point */
+    LONG(0x213); /* Flags: Unencrypted, SHA512 hashed, executable image for Cortex-M33 */
+    LONG(0); /* Reserved (image meta data) */
+  } > FLASH
+
+  /* Put the hash in a separate section for easier replacement in a post-build step */
+  .image_hash :
+  {
+    QUAD(0); /* Hash 512 bytes */
+    QUAD(0);
+    QUAD(0);
+    QUAD(0);
+    QUAD(0);
+    QUAD(0);
+    QUAD(0);
+    QUAD(0);
+  } > FLASH
+
+  .boot2 :
+  {
+    FILL(0x00);
+    QUAD(0); /* IV 256 bytes, zero for unencrypted image */
+    QUAD(0);
+    QUAD(0);
+    QUAD(0);
+
+    /* ------------------
+     * Signature block
+     * ------------------
+     */
+    __signature_block_start = .;
+    LONG(0x90000000 | (__signature_block_len << 8)); /* Tag, length, version */
+    LONG(0); /* SRK Table offset, Certificate Offset */
+    LONG(0); /* Signature offset, Blob offset */
+    LONG(0); /* Reserved */
+    __signature_block_end = .;
+    __signature_block_len = __signature_block_end - __signature_block_start;
+    __container1_end = .;
+    __container1_len = __container1_end - __container1_start;
+
+    /* DCD is replaced by XMCD. Satisfy assertions intended for other families. */
+    __dcd_start = .;
+    __dcd_end = .;
+
+    . = ORIGIN(FLASH) + 0x2000;   /* Pad to 8k alignment for the container/images boundary */
+  } > FLASH
+}
+
+/* ===--- End imxrt-boot-header-1180.x ---=== */

--- a/src/host/imxrt-boot-header.x
+++ b/src/host/imxrt-boot-header.x
@@ -8,7 +8,7 @@
  * Note that it depends on the section layout! Need to represent contiguous
  * sections starting from the boot header.
  */
-__image_size = SIZEOF(.boot) + SIZEOF(.vector_table) + SIZEOF(.text) + SIZEOF(.rodata);
+__image_size = SIZEOF(.boot) + SIZEOF(.vector_table) + SIZEOF(.xip) + SIZEOF(.text) + SIZEOF(.rodata);
 
 /* END TODO */
 EXTERN(FLEXSPI_CONFIGURATION_BLOCK);

--- a/src/host/imxrt-link.x
+++ b/src/host/imxrt-link.x
@@ -48,6 +48,7 @@ SECTIONS
 
   .vector_table : ALIGN(1024)
   {
+    FILL(0xff);
     __vector_table = .;
     __svector_table = .;
 
@@ -68,13 +69,19 @@ SECTIONS
   } > REGION_VTABLE AT> REGION_LOAD_VTABLE
   __sivector_table = LOADADDR(.vector_table);
 
-  .text :
+  /* This section guarantees VMA = LMA to allow the execute-in-place entry point to be inside the image. */
+  .xip :
   {
-    __stext = .;
-    *(.text .text.*);
-    /* Included in .text if not otherwise included in the boot header. */
+    /* Included here if not otherwise included in the boot header. */
     *(.Reset);
     *(.__pre_init);
+  } > REGION_LOAD_TEXT
+
+  .text :
+  {
+    FILL(0xff);
+    __stext = .;
+    *(.text .text.*);
     /* The HardFaultTrampoline uses the `b` instruction to enter `HardFault`,
        so must be placed close to it. */
     *(.HardFaultTrampoline);
@@ -86,6 +93,7 @@ SECTIONS
 
   .rodata : ALIGN(4)
   {
+    FILL(0xff);
     . = ALIGN(4);
     __srodata = .;
     *(.rodata .rodata.*);
@@ -100,6 +108,7 @@ SECTIONS
 
   .data : ALIGN(4)
   {
+    FILL(0xff);
     . = ALIGN(4);
     __sdata = .;
     *(.data .data.*);

--- a/src/target.rs
+++ b/src/target.rs
@@ -41,6 +41,9 @@ global_asm! {r#"
 
 __pre_init:
     ldr r0, =__imxrt_family         @ Need to know which chip family we're initializing.
+    ldr r1, =1180
+    cmp r0, r1                      @ Is this an 1180?
+    beq flexram_1180
     ldr r1, =1170
     cmp r0, r1                      @ Is this an 1170?
 
@@ -66,7 +69,14 @@ __pre_init:
     ldr r1, [r0, #64]               @ r1 = *(IMXRT_IOMUXC_GPR + 16)
     orr r1, r1, #1<<2               @ r1 |= 1 << 2
     str r1, [r0, #64]               @ *(IMXRT_IOMUXC_GPR + 16) = r1
+    b copy_from_flash
 
+    flexram_1180:
+    ldr r0, =0x444F0060             @ M33_CONFIG
+    ldr r1, =__flexram_config
+    str r1, [r0, #0]
+
+    copy_from_flash:
     # Conditionally copy text.
     ldr r0, =__stext
     ldr r2, =__sitext


### PR DESCRIPTION
The 1180 family uses a different boot header than previous families. The header is generated to support the default configuration where hash and signature errors are ignored.

The XIP `__pre_init` strategy is still used, more for ease of getting something running than because of any known problems with the boot ROM's implementation of loading images to different memories.

The boot ROM for the 1180 does not appear to allow the entry point to lie outside the (loaded or execute-in-place) image, so a new `.xip` section is added after the vector table to put the address inside the image while keeping VMA=LMA. This could cause problems for tools that manipulate binaries based on section names.

There is not yet enough board support to enable `examples/blink*`, so I have used RTT to see that the application starts with a minimal crate outside the repo.