### PR TITLE
Fix warnings, failing test, after 1.82 upgrade

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -138,5 +138,11 @@ pub fn heap_end() -> *mut u32 {
     extern "C" {
         static mut __eheap: c_void;
     }
-    unsafe { core::ptr::addr_of_mut!(__eheap) as _ }
+
+    // It used to be unsafe. Keeping it unsafe is backwards
+    // compatible.
+    #[allow(unused_unsafe)]
+    unsafe {
+        core::ptr::addr_of_mut!(__eheap) as _
+    }
 }

--- a/tests/inspect_elf.rs
+++ b/tests/inspect_elf.rs
@@ -250,7 +250,7 @@ fn imxrt1010evk() {
     let rodata = binary.section(".rodata").unwrap();
     assert_eq!(
         rodata.address,
-        0x6000_2000 + vector_table.size + aligned(text.size, 16),
+        0x6000_2000 + vector_table.size + aligned(text.size, 4),
         "rodata LMA & VMA expected behind text"
     );
     assert_eq!(rodata.address, binary.section_lma(".rodata"));


### PR DESCRIPTION
There's no requirement for 16 byte-aligned read-only data, and this is
the only assertion expecting that requirement. Reducing the alignment
lets the test pass when the image is built with a Rust 1.82 toolchain.