### PR TITLE
Remove deprecated actions-rs from CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -11,57 +11,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        components: rustfmt
+    - run: rustup toolchain install stable --no-self-update --profile minimal
     - name: Check formatting
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --verbose --all -- --check
+      run: cargo fmt --verbose --all --check
 
   clippy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        components: clippy
-    - name: Lint the host API.
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --package=imxrt-rt --tests -- -D warnings
+    - name: Install a stable toolchain with clippy
+      run: rustup toolchain install stable --no-self-update --profile minimal --component clippy
+    - name: Lint the host API
+      run: cargo clippy --package=imxrt-rt --tests -- -D warnings
 
   tests:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: thumbv7em-none-eabihf
+    - run: rustup toolchain install stable --no-self-update --profile minimal --target thumbv7em-none-eabihf
     - name: Run doc tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --doc
+      run: cargo test --doc
     - name: Run automated tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --tests -- --include-ignored
+      run: cargo test --tests -- --include-ignored
     - name: Install ARM GCC
       run: sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi
     - name: Check binaries that are linked with GNU's ld
       env:
         CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUSTFLAGS: "-C linker=arm-none-eabi-gcc -C link-arg=-mcpu=cortex-m7 -C link-arg=-mfloat-abi=hard -C link-arg=-mfpu=fpv5-d16 -C link-arg=-nostartfiles"
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --tests -- --ignored
+      run: cargo test --tests -- --ignored
 
   boards:
     runs-on: ubuntu-latest
@@ -70,20 +47,11 @@ jobs:
         board: [ teensy4, imxrt1010evk, imxrt1170evk-cm7 ]
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: thumbv7em-none-eabihf
+    - run: rustup toolchain install stable --no-self-update --profile minimal --target thumbv7em-none-eabihf --component clippy
     - name: Lint the RTIC example for ${{ matrix.board }}
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --example=blink-rtic --target=thumbv7em-none-eabihf --features=board/${{ matrix.board }},board/rtic -- -D warnings
+      run: cargo clippy --example=blink-rtic --target=thumbv7em-none-eabihf --features=board/${{ matrix.board }},board/rtic -- -D warnings
     - name: Lint the blocking example ${{ matrix.board }}
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --example=blink-blocking --target=thumbv7em-none-eabihf --features=board/${{ matrix.board }} -- -D warnings
+      run: cargo clippy --example=blink-blocking --target=thumbv7em-none-eabihf --features=board/${{ matrix.board }} -- -D warnings
 
   docs:
     runs-on: ubuntu-latest
@@ -91,11 +59,6 @@ jobs:
       RUSTDOCFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+    - run: rustup toolchain install stable --no-self-update --profile minimal
     - name: Check host documentation
-      uses: actions-rs/cargo@v1
-      with:
-        command: rustdoc
-        args: --package=imxrt-rt
+      run: cargo rustdoc --package=imxrt-rt

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -10,7 +10,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: rustup toolchain install stable --no-self-update --profile minimal
     - name: Check formatting
       run: cargo fmt --verbose --all --check
@@ -18,7 +18,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install a stable toolchain with clippy
       run: rustup toolchain install stable --no-self-update --profile minimal --component clippy
     - name: Lint the host API
@@ -27,7 +27,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: rustup toolchain install stable --no-self-update --profile minimal --target thumbv7em-none-eabihf
     - name: Run doc tests
       run: cargo test --doc
@@ -46,7 +46,7 @@ jobs:
       matrix:
         board: [ teensy4, imxrt1010evk, imxrt1170evk-cm7 ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: rustup toolchain install stable --no-self-update --profile minimal --target thumbv7em-none-eabihf --component clippy
     - name: Lint the RTIC example for ${{ matrix.board }}
       run: cargo clippy --example=blink-rtic --target=thumbv7em-none-eabihf --features=board/${{ matrix.board }},board/rtic -- -D warnings
@@ -58,7 +58,7 @@ jobs:
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: rustup toolchain install stable --no-self-update --profile minimal
     - name: Check host documentation
       run: cargo rustdoc --package=imxrt-rt


### PR DESCRIPTION
Following the same approach as https://github.com/imxrt-rs/imxrt-hal/pull/166, https://github.com/imxrt-rs/imxrt-ral/pull/48, etc.