### PR TITLE
Place .xip sections into flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+Place sections starting with `.xip` into the same load region of `.text`.
+Unlike `.text`, the contents in `.xip` will not be relocated.
+
+Four byte align both the `.xip` and `.text` sections for more predictable
+behaviors across linkers.
+
 ## [0.1.6] 2025-03-01
 
 Add new MCU targets:

--- a/examples/blink-rtic.rs
+++ b/examples/blink-rtic.rs
@@ -12,6 +12,13 @@ use imxrt_rt as _;
 /// This is checked in an automated test.
 static mut DATA: u32 = 5;
 
+#[unsafe(link_section = ".xip")]
+#[unsafe(no_mangle)]
+#[inline(never)]
+fn increment_data() {
+    unsafe { crate::DATA = crate::DATA.wrapping_add(1) };
+}
+
 #[rtic::app(device = board::rtic_support, peripherals = false)]
 mod app {
     const PIT_PERIOD_US: u32 = 1_000_000;
@@ -35,7 +42,7 @@ mod app {
 
     #[task(binds = PIT, local = [led, pit])]
     fn pit(cx: pit::Context) {
-        unsafe { crate::DATA += 1 };
+        crate::increment_data();
         cx.local.led.toggle();
         cx.local.pit.clear_interrupts();
     }

--- a/src/host/imxrt-link.x
+++ b/src/host/imxrt-link.x
@@ -70,14 +70,15 @@ SECTIONS
   __sivector_table = LOADADDR(.vector_table);
 
   /* This section guarantees VMA = LMA to allow the execute-in-place entry point to be inside the image. */
-  .xip :
+  .xip : ALIGN(4)
   {
     /* Included here if not otherwise included in the boot header. */
     *(.Reset);
     *(.__pre_init);
+    *(.xip .xip.*);
   } > REGION_LOAD_TEXT
 
-  .text :
+  .text : ALIGN(4)
   {
     FILL(0xff);
     __stext = .;


### PR DESCRIPTION
We added the `.xip` section to ensure that the reset handler and pre-init functions would be placed in flash. This commit lets users place other content into that section.

`.xip` is intended for instructions. The runtime builder will place these instructions into the same load region as `.text`. However, there's no pre-`main` relocation.