### PR TITLE
Added in_flash RuntimeBuilder constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+Introduce `RuntimeBuilder::in_flash` for creating images that can be launched
+by your own software, instead of NXP's boot ROM.
+
 Place sections starting with `.xip` into the same load region of `.text`.
 Unlike `.text`, the contents in `.xip` will not be relocated.
 

--- a/board/Cargo.toml
+++ b/board/Cargo.toml
@@ -26,6 +26,7 @@ rtt-target = { version = "0.3", optional = true, features = ["cortex-m"] }
 panic-rtt-target = { version = "0.1", optional = true, features = ["cortex-m"] }
 
 [features]
+nonboot = []
 rtic = []
 # Begin board features.
 teensy4 = [

--- a/board/build.rs
+++ b/board/build.rs
@@ -7,6 +7,16 @@ fn extract_features() -> HashSet<String> {
         .collect()
 }
 
+/// Creates a runtime for a particular family, adjusting whether the image is expected to be boot
+/// based on provided features.
+fn create_runtime(family: imxrt_rt::Family, flash_size: usize) -> imxrt_rt::RuntimeBuilder {
+    if cfg!(feature = "nonboot") {
+        imxrt_rt::RuntimeBuilder::in_flash(family, flash_size, 16 * 1024)
+    } else {
+        imxrt_rt::RuntimeBuilder::from_flexspi(family, flash_size)
+    }
+}
+
 /// Configures the runtime for a variety of boards.
 ///
 /// Note that some automated tests may check these runtimes. Feel free to change
@@ -44,15 +54,12 @@ fn main() {
             .heap_size_env_override("BOARD_HEAP")
             .build()
             .unwrap(),
-            "imxrt1170evk_cm7" => imxrt_rt::RuntimeBuilder::from_flexspi(
-                imxrt_rt::Family::Imxrt1170,
-                16 * 1024 * 1024,
-            )
-            .rodata(imxrt_rt::Memory::Dtcm)
-            .stack_size_env_override("BOARD_STACK")
-            .heap_size_env_override("BOARD_HEAP")
-            .build()
-            .unwrap(),
+            "imxrt1170evk_cm7" => create_runtime(imxrt_rt::Family::Imxrt1170, 8 * 1024 * 1024)
+                .rodata(imxrt_rt::Memory::Dtcm)
+                .stack_size_env_override("BOARD_STACK")
+                .heap_size_env_override("BOARD_HEAP")
+                .build()
+                .unwrap(),
             _ => continue,
         }
         break;

--- a/src/host/imxrt-boot-header-1180.x
+++ b/src/host/imxrt-boot-header-1180.x
@@ -101,4 +101,7 @@ SECTIONS
   } > FLASH
 }
 
+ASSERT((__dcd_end - __dcd_start) % 4 == 0, "
+ERROR(imxrt-rt): .dcd (Device Configuration Data) size must be a multiple of 4 bytes.");
+
 /* ===--- End imxrt-boot-header-1180.x ---=== */

--- a/src/host/imxrt-boot-header.x
+++ b/src/host/imxrt-boot-header.x
@@ -78,4 +78,7 @@ SECTIONS
   } > FLASH
 }
 
+ASSERT((__dcd_end - __dcd_start) % 4 == 0, "
+ERROR(imxrt-rt): .dcd (Device Configuration Data) size must be a multiple of 4 bytes.");
+
 /* ===--- End imxrt-boot-header.x ---=== */

--- a/src/host/imxrt-link.x
+++ b/src/host/imxrt-link.x
@@ -203,8 +203,6 @@ Dynamic relocations are not supported. If you are linking to C code compiled usi
 the 'cc' crate then modify your build script to compile the C code _without_
 the -fPIC flag. See the documentation of the `cc::Build.pic` method for details.");
 
-ASSERT((__dcd_end - __dcd_start) % 4 == 0, "
-ERROR(imxrt-rt): .dcd (Device Configuration Data) size must be a multiple of 4 bytes.");
 /* Do not exceed this mark in the error messages above                                    | */
 
 /* ===--- End imxrt-link.x ---=== */


### PR DESCRIPTION
Applications linked through this builder can be placed in a flash reservation. You'll need some other software to launch these programs, since they lack the boot header required by the NXP boot ROM.