### PR TITLE
Reserve address 0 by shifting ITCM start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+Establish a 32 byte reservation at the start of ITCM where instructions are
+never placed. This reduces the total capacity of ITCM by 32 bytes on nearly
+all MCUs, except the 1180.
+
 ## [0.1.7] 2025-06-14
 
 Introduce `RuntimeBuilder::in_flash` for creating images that can be launched

--- a/tests/inspect_elf.rs
+++ b/tests/inspect_elf.rs
@@ -198,7 +198,7 @@ struct Section {
 }
 
 const DTCM: u64 = 0x2000_0000;
-const ITCM: u64 = 0x0000_0000;
+const ITCM: u64 = 0x0000_0020;
 
 const fn aligned(value: u64, alignment: u64) -> u64 {
     (value + (alignment - 1)) & !(alignment - 1)


### PR DESCRIPTION
The runtime previously allowed function placement at address 0 in ITCM.
However, if you ever formed a pointer to the function placed there, it
would look like a null pointer. And you would never be able to call that
function if you relied on null pointer optimization. Also, most MCU
reference manuals (RM) recommend against this placement.

This reduces the total capacity of ITCM by 32 bytes, the smallest
possible size of a MPU region. Note that this is greater than the RM's
recommendation of a four byte reservation. It affects all supported
MCUs, except the 1180. If you're so inclined, your MPU could disallow
loads, stores, and execution from this reservation.