### PR TITLE
Add builder config for boot_header inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ the device linker script that's included in the runtime. By default, the name
 remains `device.x`. The name only matters if the "device" crate feature is
 enabled.
 
+Use `RuntimeBuilder::boot_header` to force inclusion / exclusion of the NXP
+boot ROM header in your image.
+
 ### FlexRAM bank layouts
 
 The runtime builder lets users specify the _layout_, or assignment, of FlexRAM

--- a/board/Cargo.toml
+++ b/board/Cargo.toml
@@ -30,6 +30,7 @@ panic-rtt-target = { version = "0.1", optional = true, features = ["cortex-m"] }
 
 [features]
 nonboot = []
+secondary = []
 rtic = []
 # Begin board features.
 teensy4 = [

--- a/board/build.rs
+++ b/board/build.rs
@@ -10,8 +10,10 @@ fn extract_features() -> HashSet<String> {
 /// Creates a runtime for a particular family, adjusting whether the image is expected to be boot
 /// based on provided features.
 fn create_runtime(family: imxrt_rt::Family, flash_size: usize) -> imxrt_rt::RuntimeBuilder {
-    if cfg!(feature = "nonboot") {
-        imxrt_rt::RuntimeBuilder::in_flash(family, flash_size, 16 * 1024)
+    if cfg!(feature = "nonboot") | cfg!(feature = "secondary") {
+        let mut bldr = imxrt_rt::RuntimeBuilder::in_flash(family, flash_size, 256 * 1024);
+        bldr.boot_header(cfg!(feature = "secondary"));
+        bldr
     } else {
         imxrt_rt::RuntimeBuilder::from_flexspi(family, flash_size)
     }
@@ -54,7 +56,7 @@ fn main() {
             .heap_size_env_override("BOARD_HEAP")
             .build()
             .unwrap(),
-            "imxrt1170evk_cm7" => create_runtime(imxrt_rt::Family::Imxrt1170, 8 * 1024 * 1024)
+            "imxrt1170evk_cm7" => create_runtime(imxrt_rt::Family::Imxrt1170, 256 * 1024)
                 .rodata(imxrt_rt::Memory::Dtcm)
                 .stack_size_env_override("BOARD_STACK")
                 .heap_size_env_override("BOARD_HEAP")


### PR DESCRIPTION
To form a secondary image, use in_flash to position it in flash, then override the default setting that disables the boot header.

With proper configuration, NXP's boot ROM can load a backup image. This commit reconfigures the 1170EVK board for the experiment.